### PR TITLE
CC: script: downlaod: change mirror for kernel.org

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -177,8 +177,8 @@ foreach my $mirror (@ARGV) {
 			push @extra, "$extra[0]/longterm/v$1";
 		}		
 		foreach my $dir (@extra) {
-			push @mirrors, "ftp://ftp.all.kernel.org/pub/$dir";
-			push @mirrors, "http://ftp.all.kernel.org/pub/$dir";
+			push @mirrors, "https://kernel.org/pub/$dir";
+			push @mirrors, "ftp://kernel.org/pub/$dir";
 		}
     } elsif ($mirror =~ /^\@GNOME\/(.+)$/) {
 		push @mirrors, "http://ftp.gnome.org/pub/GNOME/sources/$1";


### PR DESCRIPTION
kernel.org now suggests a different mirror address. this one also
support IPv6 connections and was faster for me.

Backport from trunk's 1f9e25d.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>